### PR TITLE
Allow JSON structured queries to be POSTed

### DIFF
--- a/group-by-json.xqy
+++ b/group-by-json.xqy
@@ -10,6 +10,10 @@ module namespace grpj = "http://marklogic.com/cts/group-by/json";
 import module namespace cts = "http://marklogic.com/cts" at "./group-by.xqy";
 import module namespace ctx = "http://marklogic.com/cts-extensions"
   at "/ext/mlpm_modules/cts-extensions/cts-extensions.xqy";
+import module namespace search = "http://marklogic.com/appservices/search"
+  at "/MarkLogic/appservices/search/search.xqy";
+import module namespace sut = "http://marklogic.com/rest-api/lib/search-util"
+  at "/MarkLogic/rest-api/lib/search-util.xqy";
 
 declare option xdmp:mapping "false";
 
@@ -56,6 +60,33 @@ declare %private function grpj:query-parser(
 };
 
 (:~
+ : construct cts:query from a JSON structured query
+ :
+ : @param $query as `map:map` or `json:object`
+ :)
+declare %private function grpj:cts-query-parser(
+  $query
+) as cts:query?
+{
+  let $json-structured-query := xdmp:to-json(map:get($query, 'query'))
+  let $search := sut:search-from-json($json-structured-query)/*
+  let $search-resolve := search:resolve(
+    $search,
+    element search:options {
+      element search:return-constraints { fn:false() },
+      element search:return-facets { fn:false() },
+      element search:return-metrics { fn:false() },
+      element search:return-plan { fn:false() },
+      element search:return-qtext { fn:false() },
+      element search:return-query { fn:true() },
+      element search:return-results { fn:false() },
+      element search:return-similar { fn:false() }
+    }
+  )
+  return ($search-resolve/search:query/element(*, cts:query)) ! cts:query(.)
+};
+
+(:~
  : evaluate map / JSON serialized cts:group-by query definitions
  :
  : @param $query as `map:map` or `json:object`
@@ -66,12 +97,13 @@ declare function grpj:query($query)
   let $columns := grpj:query-parser($query, xs:QName("cts:column"))
   let $computes := grpj:query-parser($query, xs:QName("cts:compute"))
   let $options := grpj:get-values($query, "options")
+  let $cts-query := grpj:cts-query-parser($query)
   let $result-type := (map:get($query, "result-type"), "group-by")[1]
   let $fn :=
     switch( $result-type )
-    case "group-by" return cts:group-by(?, ?)
-    case "cross-product" return cts:cross-product(?, ?)
-    case "cube" return cts:cube(?, ?)
-    default return fn:error(xs:QName("UNKOWN-FN"), "unknown group-by type: " || $result-type)
-  return $fn( ($rows, $columns, $computes), $options )
+    case "group-by" return cts:group-by(?, ?, ?)
+    case "cross-product" return cts:cross-product(?, ?, ?)
+    case "cube" return cts:cube(?, ?, ?)
+    default return fn:error(xs:QName("UNKNOWN-FN"), "unknown group-by type: " || $result-type)
+  return $fn( ($rows, $columns, $computes), $options, $cts-query )
 };


### PR DESCRIPTION
This is a change needed by the analytics-dashboard to add queries to `cts:group-by`, which currently
overwrites this file, as shown in this commit:
https://github.com/jianmin/analytics-dashboard/commit/3b1d58da2a7657b5187b3cd7b4ab26bfb4c49d2a

I would like to push this back into the group-by library, so that the analytics-dashboard component can be installed without overwriting files from this library, but it requires converting the incoming JSON structured query to a cts:query.

This, in turn, requires a dangerous call into MarkLogic's internal method
`Modules/MarkLogic/rest-api/lib/search-util.xqy#sut:search-from-json()`
to create an XML structured query. (We could duplicate the code, but
there seems to be a lot of it - I guess this could be encapsulated in another mlpm library.) Then there is a bit of brilliant hackery from Ryan Dew, calling `search:resolve` to recover the `cts:query` version of the
structured query.

For what it is worth, I also created an RFE to make these conversions
easier OOTB: https://rfetrack.marklogic.com/detail/3720

Other ideas welcome. I'd understand if you hesitate to add an internal method call to this library.
